### PR TITLE
Don't wrap functions in observables

### DIFF
--- a/knockout.wrap.js
+++ b/knockout.wrap.js
@@ -192,7 +192,7 @@
 	}
 	else
 	{
-            if (!hasES5Plugin())
+            if (!hasES5Plugin() && typeof v !== 'function')
             {
 	        var t = ko.observable();
 	        t(v);

--- a/tests/test-es5.js
+++ b/tests/test-es5.js
@@ -72,6 +72,14 @@ $(document).ready(function() {
         ok(typeof wrapped.DateObject === 'object' && wrapped.DateObject === date, 'Date value preserved');
     });
 
+    test("fromJS with functions", function() {
+        var withFunction = { 'func': function() { return 2; } };
+        var wrapped = ko.wrap.fromJS(withFunction);
+
+        ok(!ko.isObservable(wrapped.func), 'Function should not be made observable');
+        ok(typeof wrapped.func === 'function' && wrapped.func() === 2, 'Function is preserved');
+    });
+
     test("toJS date property", function() {
         var date = new Date();
         var unwrapped = ko.wrap.toJS({ 'DateObject': date });

--- a/tests/test.js
+++ b/tests/test.js
@@ -66,6 +66,14 @@ $(document).ready(function() {
         ok(typeof wrapped.DateObject === 'function' && wrapped.DateObject() === date, 'Date value preserved');
     });
 
+    test("fromJS with functions", function() {
+        var withFunction = { 'func': function() { return 2; } };
+        var wrapped = ko.wrap.fromJS(withFunction);
+
+        ok(!ko.isObservable(wrapped.func), 'Function should not be made observable');
+        ok(typeof wrapped.func === 'function' && wrapped.func() === 2, 'Function is preserved');
+    });
+
     test("toJS date property", function() {
         var date = new Date();
         var unwrapped = ko.wrap.toJS({ 'DateObject': date });


### PR DESCRIPTION
In my opinions functions in plain objects should be "preserved" and not
wrapped in observables. This also prevents double wrapping.